### PR TITLE
fix: корректное измерение скорости сети

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -267,15 +267,11 @@ export default function Home() {
         logger.warn('speedtest', `Ошибка при измерении ping: ${error instanceof Error ? error.message : String(error)}`);
       }
 
-      // Выполняем серию измерений download и upload
-      // Download и upload выполняются параллельно для каждого измерения
+      // Серия измерений: сначала download, затем upload (без конкуренции за канал).
       for (let i = 0; i < SAMPLE_COUNT; i += 1) {
         try {
-          // Запускаем download и upload параллельно (без ping, так как он уже измерен)
-          const [download, upload] = await Promise.all([
-            testDownloadSpeed(),
-            testUploadSpeed()
-          ]);
+          const download = await testDownloadSpeed();
+          const upload = await testUploadSpeed();
           
           // Добавляем только валидные (не нулевые) значения в соответствующие серии
           // Это предотвращает занижение средних значений из-за rate limiting
@@ -436,7 +432,7 @@ export default function Home() {
             {buttonLabel}
           </button>
           <p className="text-sm text-gray-400 text-center">
-            Каждое измерение выполняется {SAMPLE_COUNT} раз. Средняя скорость вычисляется по результатам серии тестов.
+            Каждое направление измеряется {SAMPLE_COUNT} раз (сначала получение, затем отдача). Средняя скорость — по серии тестов.
             {downloadSamples.length < SAMPLE_COUNT && downloadSamples.length > 0 && (
               <span className="block mt-1 text-yellow-400">
                 Выполнено {downloadSamples.length} из {SAMPLE_COUNT} измерений

--- a/src/utils/checkspeed.client.ts
+++ b/src/utils/checkspeed.client.ts
@@ -34,6 +34,20 @@ export const bytesToMbps = (bytesTransferred: number, durationSeconds: number): 
   return megabits / durationSeconds;
 };
 
+/** Время передачи полезной нагрузки без фазы установки соединения (TTFB). */
+export const resolveThroughputDurationMs = (
+  requestStartMs: number,
+  firstChunkTimeMs: number | null,
+  lastChunkTimeMs: number,
+): number => {
+  const totalDurationMs = lastChunkTimeMs - requestStartMs;
+  const transferDurationMs = firstChunkTimeMs !== null
+    ? lastChunkTimeMs - firstChunkTimeMs
+    : totalDurationMs;
+
+  return transferDurationMs > 0 ? transferDurationMs : totalDurationMs;
+};
+
 const buildDownloadUrl = (sizeMb: number) => `${DOWNLOAD_ENDPOINT}?size=${sizeMb}`;
 
 const megabytesToBytes = (sizeMb: number) => Math.round(sizeMb * 1024 * 1024);
@@ -122,14 +136,15 @@ const measureDownloadOnce = async (sizeMb: number): Promise<number> => {
 
   const totalDuration = lastChunkTime - requestStart;
   const transferDuration = firstChunkTime ? lastChunkTime - firstChunkTime : totalDuration;
+  const throughputDurationMs = resolveThroughputDurationMs(requestStart, firstChunkTime, lastChunkTime);
 
-  if (totalDuration <= 0 || bytesTransferred === 0) {
-    logger.warn('download', `Некорректные данные: duration=${totalDuration}ms, bytes=${bytesTransferred}`);
+  if (throughputDurationMs <= 0 || bytesTransferred === 0) {
+    logger.warn('download', `Некорректные данные: duration=${throughputDurationMs}ms, bytes=${bytesTransferred}`);
     return 0;
   }
 
-  // Используем общее время от начала запроса до конца передачи
-  const durationSeconds = totalDuration / 1000;
+  // Скорость считаем только по времени передачи полезной нагрузки (без TTFB/установки соединения).
+  const durationSeconds = throughputDurationMs / 1000;
   const speed = bytesToMbps(bytesTransferred, durationSeconds);
 
   logger.info('download', `Измерение завершено`, {
@@ -150,9 +165,7 @@ const measureDownloadOnce = async (sizeMb: number): Promise<number> => {
   return speed;
 };
 
-/**
- * Выполняет измерения для одного размера файла параллельно
- */
+/** Выполняет несколько последовательных измерений для одного размера файла. */
 const measureDownloadForSize = async (sizeMb: number): Promise<number> => {
   logger.debug('download', `Тестирование размера ${sizeMb} МБ`);
   const measurements: number[] = [];
@@ -195,12 +208,13 @@ const measureDownloadForSize = async (sizeMb: number): Promise<number> => {
 export const testDownloadSpeed = async (): Promise<number> => {
   logger.info('download', 'Начало тестирования download скорости');
 
-  // Запускаем измерения для всех размеров файлов параллельно
-  const sizePromises = FILE_SIZES_MB.map(async (sizeMb) => ({
-    sizeMb,
-    speed: await measureDownloadForSize(sizeMb)
-  }));
-  const aggregatedSpeeds = (await Promise.all(sizePromises)).filter((sample) => sample.speed > 0);
+  const aggregatedSpeeds: SpeedSample[] = [];
+  for (const sizeMb of FILE_SIZES_MB) {
+    const speed = await measureDownloadForSize(sizeMb);
+    if (speed > 0) {
+      aggregatedSpeeds.push({ sizeMb, speed });
+    }
+  }
 
   if (aggregatedSpeeds.length === 0) {
     logger.error('download', 'Нет успешных измерений download скорости');
@@ -336,8 +350,7 @@ const measureUploadOnce = (sizeMb: number): Promise<number> =>
 
     xhr.open('POST', UPLOAD_ENDPOINT);
     xhr.responseType = 'json';
-    // Уменьшаем таймаут до 30 секунд для serverless функций (Vercel имеет лимиты)
-    // Для файлов до 3 МБ это должно быть достаточно
+    // 30 с — лимит для serverless (Vercel); достаточно для payload до 5 МБ
     xhr.timeout = 30000; // 30 секунд таймаут
 
     xhr.upload.addEventListener('loadstart', handleLoadStart);
@@ -353,9 +366,7 @@ const measureUploadOnce = (sizeMb: number): Promise<number> =>
     xhr.send(bodyView.buffer);
   });
 
-/**
- * Выполняет измерения для одного размера файла параллельно
- */
+/** Выполняет несколько последовательных измерений для одного размера файла. */
 const measureUploadForSize = async (sizeMb: number): Promise<number> => {
   logger.debug('upload', `Тестирование размера ${sizeMb} МБ`);
   const measurements: number[] = [];
@@ -398,12 +409,13 @@ const measureUploadForSize = async (sizeMb: number): Promise<number> => {
 export const testUploadSpeed = async (): Promise<number> => {
   logger.info('upload', 'Начало тестирования upload скорости');
 
-  // Запускаем измерения для всех размеров файлов параллельно
-  const sizePromises = FILE_SIZES_MB.map(async (sizeMb) => ({
-    sizeMb,
-    speed: await measureUploadForSize(sizeMb)
-  }));
-  const aggregatedSpeeds = (await Promise.all(sizePromises)).filter((sample) => sample.speed > 0);
+  const aggregatedSpeeds: SpeedSample[] = [];
+  for (const sizeMb of FILE_SIZES_MB) {
+    const speed = await measureUploadForSize(sizeMb);
+    if (speed > 0) {
+      aggregatedSpeeds.push({ sizeMb, speed });
+    }
+  }
 
   if (aggregatedSpeeds.length === 0) {
     logger.error('upload', 'Нет успешных измерений upload скорости');
@@ -454,8 +466,12 @@ export async function testPing(): Promise<number> {
   for (let attempt = 0; attempt < PING_ATTEMPTS; attempt += 1) {
     try {
       const latency = await measurePingOnce();
-      rawMeasurements.push(latency);
-      logger.debug('ping', `Попытка ${attempt + 1}/${PING_ATTEMPTS}: ${latency.toFixed(2)} мс`);
+      if (latency > 0) {
+        rawMeasurements.push(latency);
+        logger.debug('ping', `Попытка ${attempt + 1}/${PING_ATTEMPTS}: ${latency.toFixed(2)} мс`);
+      } else {
+        logger.debug('ping', `Попытка ${attempt + 1}/${PING_ATTEMPTS}: пропущена (rate limit или нулевая задержка)`);
+      }
     } catch (error) {
       logger.warn('ping', `Попытка ${attempt + 1}/${PING_ATTEMPTS} завершилась ошибкой: ${error instanceof Error ? error.message : String(error)}`);
       // Пропускаем неудачные попытки, но продолжаем измерения
@@ -507,18 +523,16 @@ export interface SpeedTestResults {
 }
 
 /**
- * Выполняет все измерения скорости параллельно
- * Download, Upload и Ping выполняются одновременно для сокращения общего времени измерения
- * 
- * @returns Promise с результатами всех измерений
+ * Выполняет полный цикл измерений: ping → download → upload (последовательно).
+ * Направления не конкурируют за полосу пропускания, как в классических speedtest.
  */
 export async function testAllSpeeds(): Promise<SpeedTestResults> {
-  logger.info('speedtest', 'Начало параллельного тестирования всех параметров скорости');
+  logger.info('speedtest', 'Начало тестирования всех параметров скорости');
   const startTime = performance.now();
 
-  // Измеряем ping отдельно, чтобы throughput-тесты не искажали latency.
   const ping = await testPing();
-  const [download, upload] = await Promise.all([testDownloadSpeed(), testUploadSpeed()]);
+  const download = await testDownloadSpeed();
+  const upload = await testUploadSpeed();
 
   const totalTime = performance.now() - startTime;
   logger.info('speedtest', `Все измерения завершены за ${(totalTime / 1000).toFixed(2)} секунд`, {

--- a/src/utils/checkspeed.test.ts
+++ b/src/utils/checkspeed.test.ts
@@ -1,6 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { bytesToMbps, createUploadPayload, testAllSpeeds, testDownloadSpeed, testPing, testUploadSpeed } from './checkspeed.client';
+import {
+  bytesToMbps,
+  createUploadPayload,
+  resolveThroughputDurationMs,
+  testAllSpeeds,
+  testDownloadSpeed,
+  testPing,
+  testUploadSpeed,
+} from './checkspeed.client';
 import { average, averageWithoutColdStart, median, removeOutliers } from './stats';
 import { logger } from './logger';
 
@@ -42,33 +50,11 @@ const SPEED_MATRIX: number[][] = [
 // TTFB (Time To First Byte) в миллисекундах для симуляции
 const TTFB_MS = 10;
 
-// Пересчитываем ожидаемую скорость с учетом TTFB
-// Для каждого измерения: общее время = TTFB + время передачи
-// Скорость = (байты * 8) / (общее время в секундах)
-const calculateExpectedSpeed = (bytesMb: number, transferTimeMs: number, ttfbMs: number): number => {
-  const totalTimeMs = ttfbMs + transferTimeMs;
-  const bytes = bytesMb * 1024 * 1024;
-  const megabits = (bytes * 8) / (1024 * 1024);
-  return megabits / (totalTimeMs / 1000);
-};
-
 const downloadDurationsMs = SPEED_MATRIX.flat().map((speed) => {
   // Время передачи 1 МБ на данной скорости
   const transferTimeMs = (8 / speed) * 1000;
   return transferTimeMs;
 });
-
-// Пересчитываем ожидаемую скорость с учетом TTFB
-const downloadSpeedsWithTTFB = SPEED_MATRIX.flat().map((speed, index) => {
-  const sizeMb = FILE_SIZES_MB[Math.floor(index / MEASUREMENTS_PER_SIZE)];
-  const transferTimeMs = (sizeMb * 8 / speed) * 1000;
-  return calculateExpectedSpeed(sizeMb, transferTimeMs, TTFB_MS);
-});
-
-// Усредняем с учетом статистической обработки
-const EXPECTED_AGGREGATED_SPEED = Math.round(
-  downloadSpeedsWithTTFB.reduce((a, b) => a + b, 0) / downloadSpeedsWithTTFB.length
-);
 
 const MEASUREMENT_COUNT = FILE_SIZES_MB.length * MEASUREMENTS_PER_SIZE;
 
@@ -257,6 +243,17 @@ function stubXmlHttpRequest(scenarios: UploadScenario[]) {
   globalWithXhr.XMLHttpRequest = MockXMLHttpRequest as unknown as typeof XMLHttpRequest;
 }
 
+describe('resolveThroughputDurationMs', () => {
+  it('исключает TTFB из длительности передачи', () => {
+    const requestStart = 0;
+    const firstChunk = 50;
+    const lastChunk = 250;
+
+    expect(resolveThroughputDurationMs(requestStart, firstChunk, lastChunk)).toBe(200);
+    expect(resolveThroughputDurationMs(requestStart, null, lastChunk)).toBe(250);
+  });
+});
+
 describe('bytesToMbps', () => {
   it('конвертирует байты и секунды в Мбит/с', () => {
     const oneMbInBytes = 1 * 1024 * 1024;
@@ -395,7 +392,6 @@ describe('testDownloadSpeed', () => {
 
     const result = await testDownloadSpeed();
 
-    // Проверяем, что результат близок к ожидаемому (с учетом погрешности округления)
     expect(result).toBeGreaterThan(0);
     expect(fetchMock).toHaveBeenCalledTimes(MEASUREMENT_COUNT);
   });
@@ -560,7 +556,7 @@ describe('testPing', () => {
 });
 
 describe('testAllSpeeds', () => {
-  it('должен выполнить все три теста параллельно и вернуть результаты', async () => {
+  it('выполняет ping, затем download и upload последовательно', async () => {
     // Мокаем fetch для download и ping
     const downloadBytes = FILE_SIZES_MB.reduce((acc, size) => acc + size * 1024 * 1024, 0);
     const downloadChunks = Math.ceil(downloadBytes / DOWNLOAD_CHUNK_BYTES);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Проблема

Измерения занижали или искажали реальную пропускную способность из‑за конкуренции потоков и включения времени установки соединения (TTFB) в расчёт download.

## Изменения

- **Последовательная модель** (как у Ookla/RMBT): ping → download → upload; размеры 2 МБ и 5 МБ измеряются по очереди, а не параллельно.
- **Download throughput**: скорость считается только по времени передачи полезной нагрузки (`resolveThroughputDurationMs`), без TTFB.
- **Ping**: сэмплы с нулевой задержкой (429 rate limit) не попадают в медиану.
- **UI**: в каждой итерации сначала download, затем upload — без деления канала пополам.

## Проверка

- `npm test` — 38 тестов
- `npm run lint`
- `npm run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-48b857e8-0d98-4530-acee-3857d68093e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-48b857e8-0d98-4530-acee-3857d68093e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

